### PR TITLE
Panic if nats connection closed

### DIFF
--- a/listener/proposal.go
+++ b/listener/proposal.go
@@ -7,6 +7,7 @@ package listener
 import (
 	"encoding/json"
 	"errors"
+	"time"
 
 	v2 "github.com/mysteriumnetwork/discovery/proposal/v2"
 
@@ -30,7 +31,16 @@ func New(brokerURL string, repository *proposal.Repository) *Listener {
 }
 
 func (l *Listener) Listen() error {
-	conn, err := nats.Connect(l.brokerURL)
+	var opts = func(opts *nats.Options) error {
+		opts.PingInterval = time.Second * 5
+		opts.MaxReconnect = 5
+		opts.ClosedCB = func(c *nats.Conn) {
+			panic("nats connection closed")
+		}
+		return nil
+	}
+
+	conn, err := nats.Connect(l.brokerURL, opts)
 	if err != nil {
 		return err
 	}

--- a/proposal/service.go
+++ b/proposal/service.go
@@ -77,7 +77,7 @@ func (s *Service) List(opts ListOpts) ([]v2.Proposal, error) {
 		// exclude monitoringFailed nodes
 		sessionsResponse, err := s.qualityService.Sessions(opts.from)
 		if err != nil {
-			log.Warn().Err(err).Msgf("Could not fetch session stats for consumer", opts.from)
+			log.Warn().Err(err).Msgf("Could not fetch session stats for consumer %v", opts.from)
 		} else {
 			for k, proposal := range resultMap {
 				if sessionsResponse.MonitoringFailed(proposal.ProviderID, proposal.ServiceType) {


### PR DESCRIPTION
The default config for nats driver will attempt to reconnect for 60 times, then just close the connection and do nothing. 

Made a patch where we'll try to reconnect 5 times and trigger a panic if we do not succeed. This should trigger a container restart and an alert(in the future).

Closes mysteriumnetwork/node#3685