### PR TITLE
Add internal routes for proposals API to get all proposals

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -34,7 +34,8 @@ type Options struct {
 	UniverseJWTSecret string
 	SentinelURL       string
 
-	DevPass string
+	DevPass      string
+	InternalPass string
 
 	MaxRequestsLimit int
 
@@ -81,6 +82,7 @@ func ReadDiscovery() (*Options, error) {
 	}
 
 	devPass := OptionalEnv("DEV_PASS", "")
+	internalPass := OptionalEnv("INTERNAL_PASS", "")
 	logLevel := OptionalEnv("LOG_LEVEL", "debug")
 
 	maxRequestsLimit := OptionalEnv("MAX_REQUESTS_LIMIT", "1000")
@@ -99,6 +101,7 @@ func ReadDiscovery() (*Options, error) {
 		LocationPass:        locationPass,
 		MaxRequestsLimit:    limit,
 		DevPass:             devPass,
+		InternalPass:        internalPass,
 		ProposalsCacheTTL:   *proposalsCacheTTL,
 		ProposalsCacheLimit: proposalsCacheLimit,
 		CountriesCacheLimit: countriesCacheLimit,

--- a/health/api.go
+++ b/health/api.go
@@ -52,7 +52,9 @@ func NewAPI() *API {
 	return &API{}
 }
 
-func (a *API) RegisterRoutes(r gin.IRoutes) {
-	r.GET("/ping", a.Ping)
-	r.GET("/status", a.Status)
+func (a *API) RegisterRoutes(routers ...gin.IRoutes) {
+	for _, r := range routers {
+		r.GET("/ping", a.Ping)
+		r.GET("/status", a.Status)
+	}
 }

--- a/proposal/inmemory.go
+++ b/proposal/inmemory.go
@@ -61,7 +61,7 @@ func NewRepository(enhancers []Enhancer) *Repository {
 	}
 }
 
-func (r *Repository) List(opts repoListOpts) (res []v3.Proposal) {
+func (r *Repository) List(opts repoListOpts, limited bool) (res []v3.Proposal) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -91,8 +91,8 @@ func (r *Repository) List(opts repoListOpts) (res []v3.Proposal) {
 
 		countryLimit[p.proposal.Location.Country]++
 
-		if countryLimit[p.proposal.Location.Country] <= countryHardLimit {
-			if countryLimit[p.proposal.Location.Country] <= countrySoftLimit || countryLimit[p.proposal.Location.Country]%10 == 0 {
+		if !limited || countryLimit[p.proposal.Location.Country] <= countryHardLimit {
+			if !limited || countryLimit[p.proposal.Location.Country] <= countrySoftLimit || countryLimit[p.proposal.Location.Country]%10 == 0 {
 				res = append(res, p.proposal)
 			}
 		}

--- a/proposal/service.go
+++ b/proposal/service.go
@@ -45,7 +45,7 @@ type ListOpts struct {
 	presetID                int
 }
 
-func (s *Service) List(opts ListOpts) []v3.Proposal {
+func (s *Service) List(opts ListOpts, limited bool) []v3.Proposal {
 	proposals := s.Repository.List(repoListOpts{
 		providerIDS:        opts.providerIDS,
 		serviceType:        opts.serviceType,
@@ -56,7 +56,7 @@ func (s *Service) List(opts ListOpts) []v3.Proposal {
 		compatibilityMin:   opts.compatibilityMin,
 		compatibilityMax:   opts.compatibilityMax,
 		tags:               opts.tags,
-	})
+	}, limited)
 
 	or := &metrics.OracleResponses{}
 	or.Load(s.qualityService, opts.from)
@@ -77,7 +77,7 @@ func (s *Service) Metadata(opts repoMetadataOpts) []v3.Metadata {
 	return s.Repository.Metadata(opts, or.QualityResponse)
 }
 
-func (s *Service) ListCountriesNumbers(opts ListOpts) map[string]int {
+func (s *Service) ListCountriesNumbers(opts ListOpts, limited bool) map[string]int {
 	if opts.presetID == 0 {
 		return s.Repository.ListCountriesNumbers(repoListOpts{
 			providerIDS:        opts.providerIDS,
@@ -102,7 +102,7 @@ func (s *Service) ListCountriesNumbers(opts ListOpts) map[string]int {
 		compatibilityMin:   opts.compatibilityMin,
 		compatibilityMax:   opts.compatibilityMax,
 		tags:               opts.tags,
-	})
+	}, limited)
 
 	or := &metrics.OracleResponses{}
 	or.Load(s.qualityService, opts.from)


### PR DESCRIPTION
This pull request adds internal routes to the proposals API that allow retrieving all proposals. The internal routes are protected with basic authentication. This change improves the functionality of the proposals API by providing an additional endpoint for internal use.