### PR TITLE
Add hard and soft limits configuration per country

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	tagEnhancer := tags.NewEnhancer(tags.NewApi(cfg.BadgerAddress.String()))
-	proposalRepo := proposal.NewRepository([]proposal.Enhancer{tagEnhancer})
+	proposalRepo := proposal.NewRepository([]proposal.Enhancer{tagEnhancer}, cfg.ProposalsHardLimitPerCountry, cfg.ProposalsSoftLimitPerCountry)
 	qualityOracleAPI := oracleapi.New(cfg.QualityOracleURL.String())
 	qualityService := quality.NewService(qualityOracleAPI, cfg.QualityCacheTTL)
 	proposalService := proposal.NewService(proposalRepo, qualityService)

--- a/config/options.go
+++ b/config/options.go
@@ -37,6 +37,9 @@ type Options struct {
 	DevPass      string
 	InternalPass string
 
+	ProposalsHardLimitPerCountry int
+	ProposalsSoftLimitPerCountry int
+
 	MaxRequestsLimit int
 
 	ProposalsCacheTTL   time.Duration
@@ -85,6 +88,15 @@ func ReadDiscovery() (*Options, error) {
 	internalPass := OptionalEnv("INTERNAL_PASS", "")
 	logLevel := OptionalEnv("LOG_LEVEL", "debug")
 
+	proposalsHardLimitPerCountry, err := OptionalEnvInt("PROPOSALS_HARD_LIMIT_PER_COUNTRY", "1000")
+	if err != nil {
+		return nil, err
+	}
+	proposalsSoftLimitPerCountry, err := OptionalEnvInt("PROPOSALS_SOFT_LIMIT_PER_COUNTRY", "1000")
+	if err != nil {
+		return nil, err
+	}
+
 	maxRequestsLimit := OptionalEnv("MAX_REQUESTS_LIMIT", "1000")
 	limit, err := strconv.Atoi(maxRequestsLimit)
 	if err != nil {
@@ -92,20 +104,22 @@ func ReadDiscovery() (*Options, error) {
 	}
 
 	return &Options{
-		QualityOracleURL:    *qualityOracleURL,
-		QualityCacheTTL:     *qualityCacheTTL,
-		BrokerURL:           *brokerURL,
-		BadgerAddress:       *badgerAddress,
-		LocationAddress:     *locationAddress,
-		LocationUser:        locationUser,
-		LocationPass:        locationPass,
-		MaxRequestsLimit:    limit,
-		DevPass:             devPass,
-		InternalPass:        internalPass,
-		ProposalsCacheTTL:   *proposalsCacheTTL,
-		ProposalsCacheLimit: proposalsCacheLimit,
-		CountriesCacheLimit: countriesCacheLimit,
-		LogLevel:            logLevel,
+		QualityOracleURL:             *qualityOracleURL,
+		QualityCacheTTL:              *qualityCacheTTL,
+		BrokerURL:                    *brokerURL,
+		BadgerAddress:                *badgerAddress,
+		LocationAddress:              *locationAddress,
+		LocationUser:                 locationUser,
+		LocationPass:                 locationPass,
+		MaxRequestsLimit:             limit,
+		DevPass:                      devPass,
+		InternalPass:                 internalPass,
+		ProposalsCacheTTL:            *proposalsCacheTTL,
+		ProposalsCacheLimit:          proposalsCacheLimit,
+		CountriesCacheLimit:          countriesCacheLimit,
+		LogLevel:                     logLevel,
+		ProposalsHardLimitPerCountry: proposalsHardLimitPerCountry,
+		ProposalsSoftLimitPerCountry: proposalsSoftLimitPerCountry,
 	}, nil
 }
 


### PR DESCRIPTION
This pull request adds the functionality to configure hard and soft limits per country for proposals. It introduces two new options, `ProposalsHardLimitPerCountry` and `ProposalsSoftLimitPerCountry`, which allow setting the maximum number of proposals allowed per country. The `List` method in the `Repository` struct has been updated to enforce these limits when retrieving proposals. This change improves the flexibility and control over proposal limits, enabling better management of resources.