### PR TITLE
Update Go toolchain to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.2-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add build-base
 WORKDIR /go/src/github.com/mysteriumnetwork/discovery

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM golang:1.25.2-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add build-base
 WORKDIR /go/src/github.com/mysteriumnetwork/discovery

--- a/Dockerfile.e2e.pricer
+++ b/Dockerfile.e2e.pricer
@@ -1,4 +1,4 @@
-FROM golang:1.25.2-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add build-base
 WORKDIR /go/src/github.com/mysteriumnetwork/discovery

--- a/Dockerfile.pricer
+++ b/Dockerfile.pricer
@@ -1,4 +1,4 @@
-FROM golang:1.25.2-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add build-base
 WORKDIR /go/src/github.com/mysteriumnetwork/discovery

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mysteriumnetwork/discovery
 
-go 1.24.2
+go 1.26
 
 require (
 	github.com/ReneKroon/ttlcache/v2 v2.9.0

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add build-base
 WORKDIR /go/src/github.com/mysteriumnetwork/discovery


### PR DESCRIPTION
- Bump Go version in go.mod
- Update Docker builder images to golang:1.26-alpine